### PR TITLE
Fix link to FOSDEM 2025 devroom schedule

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 # Identity and Access Management Devroom @ FOSDEM'2025
 
 [FOSDEM 2025](https://fosdem.org/2025/) will have an [identity and access management
-devroom](https://fosdem.org/2025/schedule/track/identity-and-access-management/).
+devroom](https://fosdem.org/2025/schedule/track/iam/).
 
 The IAM devroom is scheduled to be held on the **Sunday**,
 **February 2nd, 2025** in Brussels, Belgium at [ULB](http://www.ulb.ac.be/).


### PR DESCRIPTION
Somehow, new URL is /iam, not /identity-and-access-management as before.